### PR TITLE
Error after callApi (result of buildPaymentPageUrl)

### DIFF
--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -486,7 +486,7 @@ final class ApiClient {
 	private function buildRequestUrl($path, $queryParams) {
 		$url = $this->getBasePath() . $path;
 		if (!empty($queryParams)) {
-			$url = ($url . '?' . http_build_query($queryParams));
+			$url = ($url . '?' . http_build_query($queryParams, '', '&'));
 		}
 		return $url;
 	}


### PR DESCRIPTION
The sent request does either not contain the request parameter 'id' or it is invalid (e.g. wrong format).

The call from API returns this error. Upon further inspection, I found that this is caused by the buildRequestUrl method which uses http_build_query function which by default uses '&' as a separator. Normally if posting to another php5.3 machine this will not be a problem.

But if you post to a server with a newer PHP version or tomcat java server or something else the & might not be handled properly.

To overcome this specify:

http_build_query($array, '', '&');

and NOT

http_build_query($array);