### PR TITLE
Bumped version `firebase/php-jwt` from 6.8 to 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "firebase/php-jwt": "^6.8",
+        "firebase/php-jwt": "^7.0",
         "guzzlehttp/guzzle": "^7.7",
         "guzzlehttp/psr7": "^2.5"
     },


### PR DESCRIPTION
The wallee/sdk v5 requires firebase/php-jwt ^6.8, but Composer blocks v6.x due to a security advisory (CVE-2025-45769 - low severity, "weak encryption" in jwt < 7.0.0).